### PR TITLE
Make default values for fields bytes

### DIFF
--- a/puttykeys/__init__.py
+++ b/puttykeys/__init__.py
@@ -13,9 +13,9 @@ def get_binio(bytes):
 def ppkraw_to_openssh(ppkraw, passphrase = ''):
   lines = [l.strip() for l in ppkraw.strip().split('\n')]
   if lines[0].startswith('PuTTY-User-Key-File-2:'):
-    privbin = ''
-    pubbin = ''
-    comment = ''
+    privbin = b''
+    pubbin = b''
+    comment = b''
     hexmac = False
     for i in range(0,len(lines)):
       if lines[i].startswith('Public-Lines: '):


### PR DESCRIPTION
Hi,
I noticed this library crashes since on line 49 your concatenating bytes to one of the variables defined at the beginning, but if they aren't updated the default string values are kept, therefore failing since `bytes + str` is not implemented.

This fixes the issue